### PR TITLE
Fix publishing

### DIFF
--- a/himon/__init__.py
+++ b/himon/__init__.py
@@ -1,6 +1,6 @@
 """himon package entry file."""
 
-__version__ = "0.6.0"
+__version__ = "0.6.1"
 __all__ = ["__version__", "get_cache_root"]
 
 import os

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,9 +50,7 @@ docs = [
 ]
 test = [
   "pytest >= 8.2.2",
-  "pytest-cov >= 5.0.0",
-  "tox >= 4.15.1",
-  "tox-rye @ git+https://github.com/bluss/tox-rye"
+  "pytest-cov >= 5.0.0"
 ]
 
 [project.urls]
@@ -128,5 +126,7 @@ keep-runtime-typing = true
 
 [tool.rye]
 dev-dependencies = [
-  "pre-commit >= 3.5.0"
+  "pre-commit >= 3.5.0",
+  "tox >= 4.15.1",
+  "tox-rye @ git+https://github.com/bluss/tox-rye"
 ]

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -163,9 +163,7 @@ tomli==2.0.1
     # via pytest
     # via tox
 tox==4.15.1
-    # via himon
 tox-rye @ git+https://github.com/bluss/tox-rye@d1348e996d642e947cd0fb158ecdbcfe0f386af3
-    # via himon
 typing-extensions==4.12.2
     # via annotated-types
     # via mkdocstrings


### PR DESCRIPTION
Moves `tox` and `tox-rye` to dev dependencies